### PR TITLE
eslint, editorconfig, gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,67 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:prettier/recommended",
+    "plugin:react/recommended"
+  ],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "settings": {
+    "react": {
+      "version": "18.2.0"
+    }
+  },
+  "plugins": ["prettier"],
+  "rules": {
+    "react-hooks/exhaustive-deps": "off",
+    "react/react-in-jsx-scope": 0,
+    "react/jsx-props-no-spreading": 0,
+    "jsx-a11y/anchor-is-valid": 0,
+    "max-len": ["error", {"code": 150}],
+    "no-plusplus": "off",
+    "jsx-a11y/click-events-have-key-events": "off",
+    "jsx-a11y/no-noninteractive-element-interactions": "off",
+    "react/no-array-index-key": "off",
+    "curly": "error",
+    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "linebreak-style": ["error", "unix"],
+    "lines-between-class-members": ["error", "always"],
+    "prettier/prettier": [
+      "error",
+      {
+        "trailingComma": "all",
+        "semi": true,
+        "singleQuote": true,
+        "tabWidth": 2,
+        "printWidth": 100,
+        "arrowParens": "avoid"
+      }
+    ],
+    "sort-keys": "off",
+    "padding-line-between-statements": [
+      "error",
+      { "blankLine": "always", "prev": "*", "next": "block" },
+      { "blankLine": "always", "prev": "*", "next": "multiline-const" },
+      { "blankLine": "any", "prev": "*", "next": "import" }
+    ],
+    "no-duplicate-imports": "error",
+    "no-trailing-spaces": "error",
+    "no-import-assign": "error",
+    "no-unsafe-finally": "off",
+    "no-console": [
+      "warn",
+      {
+        "allow": ["info", "warn", "error"]
+      }
+    ]
+  }
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text eol=lf
+*.pdf binary
+*.jpg binary
+*.jpeg binary
+*.png binary

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint ./src",
+    "lint:fix": "eslint ./src --fix"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
В проект добавлены новые зависимости, поэтому после git pull нужно будет выполнить `npm ci`

### .editorconfig

Нужно установить в vscode плагин [editorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) - в сочетании с файлом .editorconfig он говорит IDE, какая должна быть ширина табуляции, пользоваться при этом табом или пробелами, какую использовать кодировку, и т.п.

### eslint

https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint - с помощью плагинов для eslint и конфига .eslintrc.json помогает поддерживать чистоту и единообразие стиля написания кода, а также подсказывает о потенциальных ошибках

очень удобно настроить автофиксы по Ctrl+S:
1. Ctrl+Shift+P
2. ![image](https://github.com/SergeySRybakov/DashBoard/assets/26201525/2e86d3a0-6d31-4aca-8762-ce46fee247c6)
3. ```
    "editor.codeActionsOnSave": {
        "source.fixAll.eslint": true
    }```

Также в package.json добавлено два новых скрипта:
- `npm run lint` - проверить ошибки и предупреждения линтера
- `npm run lint:fix` - попросить линтер автоматически исправить все, что он сможет

### gitattributes

Использую для настроек git в части работы с переносами строк (они разные для windows и linux).

После настройки eslint и добавления плагина, скорее всего, eslint начнет ругаться на переносы строк, т.к. они в виндовом формате. Для переведения их к желаемому виду нужно выполнить
```
git read-tree --empty   # Clean index, force re-scan of working directory
git add .
git rm --cached -r .
git reset --hard
```